### PR TITLE
https://wallet.lisknode.io is deprecated

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
 	"coin": "LISK",
-	"node": "https://wallet.lisknode.io",
+	"node": "http://localhost:8000",
 	"nodepay": "http://localhost:8000",
 	"pubkey": "120d1c3847bd272237ee712ae83de59bbeae127263196fc0f16934bcfa82d8a4",
 	"percentage": 15,


### PR DESCRIPTION
Since https://wallet.lisknode.io is deprecated I think keeping it there will just confuse users, it certainly confused me - instead perhaps giving them an example of something that may indeed work like the localhost with port 8000 for the mainnet would be better.