### PR TITLE
Update liskpool.py such that the payments.sh it creates can be called…

### DIFF
--- a/liskpool.py
+++ b/liskpool.py
@@ -150,7 +150,7 @@ def pool ():
 			SUFFIX = 'X'
 
 		f.write ("echo Starting dpos-api-fallback\n")
-		f.write ("node dpos-api-fallback/dist/index.js start -n " + conf['nodepay'] + " -s " + SUFFIX + "&\n")
+		f.write ("node $(dirname $0)/dpos-api-fallback/dist/index.js start -n " + conf['nodepay'] + " -s " + SUFFIX + "&\n")
 		f.write ("DPOSFALLBACK_PID=$!\n")
 		f.write ("sleep 4\n")
 


### PR DESCRIPTION
… from anywhere.

By adding "$(dirname $0)/" to the node command, a call of /bin/bash ***/payments.sh will end up working fine from any path. Otherwise you need to execute "payments.sh" from the same directory it lives in for the dpos-api-fallback to work.