### PR TITLE
Docs: Use Lisk Commander v2.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ First clone the lisk-pool repository and install requests:
 If you are using lisk, you need to install lisk commander:
 
 ```bash
-npm install --global --production lisk-commander
+npm install --global --production lisk-commander@2.2.3
 ```
 
 ### Rise


### PR DESCRIPTION
This PR updates the docs to use the latest v2 release of Lisk Commander.

Installing Lisk Commander with `npm install --global --production lisk-commander` installs version 3+. This version is not compatible with the current network, as it produced transactions with different types (eg. tranfer = type 8 instead of 0).

See the following issue for reference: https://github.com/LiskHQ/lisk-sdk/issues/4801